### PR TITLE
Update mappings to stable_29

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,4 +2,4 @@ version=2.1.0
 api_version=2.2.0
 minecraft_version=1.10.2
 forge_version=12.18.2.2123
-mappings_version=snapshot_20160518
+mappings_version=stable_29

--- a/java/squeek/applecore/api/hunger/ExhaustionEvent.java
+++ b/java/squeek/applecore/api/hunger/ExhaustionEvent.java
@@ -102,7 +102,7 @@ public abstract class ExhaustionEvent extends Event
 			if (!shouldDecreaseSaturationLevel)
 				deltaSaturation = 0f;
 
-			EnumDifficulty difficulty = player.worldObj.getDifficulty();
+			EnumDifficulty difficulty = player.world.getDifficulty();
 			boolean shouldDecreaseFoodLevel = !shouldDecreaseSaturationLevel && difficulty != EnumDifficulty.PEACEFUL;
 
 			if (!shouldDecreaseFoodLevel)

--- a/java/squeek/applecore/api/hunger/StarvationEvent.java
+++ b/java/squeek/applecore/api/hunger/StarvationEvent.java
@@ -86,7 +86,7 @@ public abstract class StarvationEvent extends Event
 		{
 			super(player);
 
-			EnumDifficulty difficulty = player.worldObj.getDifficulty();
+			EnumDifficulty difficulty = player.world.getDifficulty();
 			boolean shouldDoDamage = player.getHealth() > 10.0F || difficulty == EnumDifficulty.HARD || player.getHealth() > 1.0F && difficulty == EnumDifficulty.NORMAL;
 
 			if (!shouldDoDamage)

--- a/java/squeek/applecore/asm/Hooks.java
+++ b/java/squeek/applecore/asm/Hooks.java
@@ -54,7 +54,7 @@ public class Hooks
 			}
 		}
 
-		boolean hasNaturalRegen = player.worldObj.getGameRules().getBoolean("naturalRegeneration");
+		boolean hasNaturalRegen = player.world.getGameRules().getBoolean("naturalRegeneration");
 
 		Result allowSaturatedRegenResult = Hooks.fireAllowSaturatedRegenEvent(player);
 		boolean shouldDoSaturatedRegen = allowSaturatedRegenResult == Result.ALLOW || (allowSaturatedRegenResult == Result.DEFAULT && hasNaturalRegen && foodStats.getSaturationLevel() > 0.0F && player.shouldHeal() && foodStats.getFoodLevel() >= 20);

--- a/java/squeek/applecore/asm/module/ModuleFoodEatingSpeed.java
+++ b/java/squeek/applecore/asm/module/ModuleFoodEatingSpeed.java
@@ -67,7 +67,7 @@ public class ModuleFoodEatingSpeed implements IClassTransformerModule
 		InsnList replacement = new InsnList();
 		replacement.add(new VarInsnNode(ALOAD, 0));
 		replacement.add(new FieldInsnNode(GETFIELD, ObfHelper.getInternalClassName(ASMConstants.ITEM_RENDERER), ObfHelper.isObfuscated() ? "field_78455_a" : "mc", ASMHelper.toDescriptor(ASMConstants.MINECRAFT)));
-		replacement.add(new FieldInsnNode(GETFIELD, ObfHelper.getInternalClassName(ASMConstants.MINECRAFT), ObfHelper.isObfuscated() ? "field_71439_g" : "thePlayer", ASMHelper.toDescriptor(ASMConstants.PLAYER_SP)));
+		replacement.add(new FieldInsnNode(GETFIELD, ObfHelper.getInternalClassName(ASMConstants.MINECRAFT), ObfHelper.isObfuscated() ? "field_71439_g" : "player", ASMHelper.toDescriptor(ASMConstants.PLAYER_SP)));
 		replacement.add(new FieldInsnNode(GETFIELD, ObfHelper.getInternalClassName(ASMConstants.PLAYER), "itemInUseMaxDuration", "I"));
 
 		boolean replaced = ASMHelper.findAndReplace(method.instructions, needle, replacement) != null;

--- a/java/squeek/applecore/asm/reference/EntityPlayerModifications.java
+++ b/java/squeek/applecore/asm/reference/EntityPlayerModifications.java
@@ -36,7 +36,7 @@ public abstract class EntityPlayerModifications extends EntityPlayer
 			// added:
 			this.itemInUseMaxDuration = duration;
 
-			if (!this.worldObj.isRemote)
+			if (!this.world.isRemote)
 			{
 				int i = 1;
 
@@ -67,7 +67,7 @@ public abstract class EntityPlayerModifications extends EntityPlayer
 		}
 
 		// modified
-		if (this.worldObj.getDifficulty() == EnumDifficulty.PEACEFUL && this.worldObj.getGameRules().getBoolean("naturalRegeneration"))
+		if (this.world.getDifficulty() == EnumDifficulty.PEACEFUL && this.world.getGameRules().getBoolean("naturalRegeneration"))
 		{
 			if (this.getHealth() < this.getMaxHealth() && this.ticksExisted % 20 == 0)
 			{

--- a/java/squeek/applecore/asm/reference/ItemRendererModifications.java
+++ b/java/squeek/applecore/asm/reference/ItemRendererModifications.java
@@ -10,7 +10,7 @@ public class ItemRendererModifications
 	private void transformEatFirstPerson(float p_187454_1_, EnumHandSide p_187454_2_, ItemStack p_187454_3_)
 	{
 		Object mc_thePlayer = null;
-		float f = (float)this.mc.thePlayer.getItemInUseCount() - p_187454_1_ + 1.0F;
+		float f = (float)this.mc.player.getItemInUseCount() - p_187454_1_ + 1.0F;
 		// this is actually this.mc.thePlayer; a dummy is used here to show which field we are accessing
 		float f1 = f / (float) ((EntityPlayerModifications) mc_thePlayer).itemInUseMaxDuration;
 	}

--- a/java/squeek/applecore/commands/CommandHunger.java
+++ b/java/squeek/applecore/commands/CommandHunger.java
@@ -14,13 +14,13 @@ import java.util.List;
 public class CommandHunger extends CommandBase
 {
 	@Override
-	public String getCommandName()
+	public String getName()
 	{
 		return "hunger";
 	}
 
 	@Override
-	public String getCommandUsage(ICommandSender icommandsender)
+	public String getUsage(ICommandSender icommandsender)
 	{
 		return "applecore.commands.hunger.usage";
 	}
@@ -47,15 +47,15 @@ public class CommandHunger extends CommandBase
 		}
 		else
 		{
-			throw new WrongUsageException(getCommandUsage(commandSender));
+			throw new WrongUsageException(getUsage(commandSender));
 		}
 	}
 
 	@Override
-	public List<String> getTabCompletionOptions(MinecraftServer server, ICommandSender sender, String[] args, BlockPos pos)
+	public List<String> getTabCompletions(MinecraftServer server, ICommandSender sender, String[] args, BlockPos pos)
 	{
 		if (args.length == 1)
-			return getListOfStringsMatchingLastWord(args, server.getAllUsernames());
+			return getListOfStringsMatchingLastWord(args, server.getOnlinePlayerNames());
 		else
 			return null;
 	}

--- a/java/squeek/applecore/network/MessageDifficultySync.java
+++ b/java/squeek/applecore/network/MessageDifficultySync.java
@@ -39,7 +39,7 @@ public class MessageDifficultySync implements IMessage, IMessageHandler<MessageD
 		Minecraft.getMinecraft().addScheduledTask(new Runnable() {
 			@Override
 			public void run() {
-				NetworkHelper.getSidedPlayer(ctx).worldObj.getWorldInfo().setDifficulty(message.difficulty);
+				NetworkHelper.getSidedPlayer(ctx).world.getWorldInfo().setDifficulty(message.difficulty);
 			}
 		});
 		return null;

--- a/java/squeek/applecore/network/SyncHandler.java
+++ b/java/squeek/applecore/network/SyncHandler.java
@@ -35,7 +35,7 @@ public class SyncHandler
 		if (!(event.player instanceof EntityPlayerMP))
 			return;
 
-		CHANNEL.sendTo(new MessageDifficultySync(event.player.worldObj.getDifficulty()), (EntityPlayerMP) event.player);
+		CHANNEL.sendTo(new MessageDifficultySync(event.player.world.getDifficulty()), (EntityPlayerMP) event.player);
 	}
 
 	@SubscribeEvent


### PR DESCRIPTION
This is nothing much, but projects I'm working on (not alone) are using the stable_29 mappings, and libs we use are on stable_29 too, therefore I  could not use AppleCore in its state.
While using this new version requires one to use stable_29 mappings to use it in any project, I believe these mappings to be preferred over the 8 months old snapshot that was used before.

Also, please note this change will only affect developers and not the end-user (only deobfuscated environment is affected).