### PR TITLE
Fix #150: /hunger permission level too high

### DIFF
--- a/java/squeek/applecore/commands/CommandHunger.java
+++ b/java/squeek/applecore/commands/CommandHunger.java
@@ -32,7 +32,7 @@ public class CommandHunger extends CommandBase
 	@Override
 	public int getRequiredPermissionLevel()
 	{
-		return 4;
+		return 2;
 	}
 
 	@Override


### PR DESCRIPTION
Permission level 4 is only meant for things like /save-all, /save-off, /save-on, /stop, and /publish.